### PR TITLE
feat: Add curl|bash tmux installer with stable paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# Gas Town Helper - Agent Instructions
+
+This repository contains setup scripts for Gas Town tmux configuration.
+
+## Quick Reference
+
+### Install tmux config (one-liner)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erkantaylan/gastown-helper/master/install-tmux.sh | bash
+```
+
+This downloads scripts to `~/.local/share/gt-tmux/` and installs `~/.config/tmux/tmux.conf`.
+
+### Enable second status line
+
+After installing, enable the rig overview status line:
+
+```bash
+~/.local/share/gt-tmux/tmux-rig-status-setup.sh
+```
+
+### Set mayor name
+
+```bash
+echo 'YourName' > ~/.gt-mayor-name
+```
+
+### Reload tmux config
+
+```bash
+tmux source-file ~/.config/tmux/tmux.conf
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `install-tmux.sh` | curl\|bash installer for standalone tmux config |
+| `tmux.conf` | Main tmux configuration with Gas Town status bar |
+| `tmux-rig-status.sh` | Second status line showing rig overview |
+| `tmux-status-right.sh` | First line filter (strips rig LEDs) |
+| `tmux-rig-status-setup.sh` | One-time setup for second status line |
+| `claude-statusline.sh` | Claude Code status line helper |
+
+## Installation Paths
+
+Scripts detect their location in this priority:
+
+1. `GT_TMUX_DIR` env var (custom location)
+2. `~/.local/share/gt-tmux/` (curl|bash install)
+3. `$GT_HOME/gthelper/` (manual install)
+
+## Requirements
+
+- `tmux` (terminal multiplexer)
+- `curl` (for installer)
+- `python3` (for status parsing)
+- `gt` CLI (Gas Town binary - for status display)
+
+## Troubleshooting
+
+### Scripts not found
+
+If you see "Could not find tmux-rig-status.sh", either:
+- Run `install-tmux.sh` to install scripts
+- Set `GT_HOME` to your Gas Town directory
+- Set `GT_TMUX_DIR` to your scripts location
+
+### Status bar shows "gt: offline"
+
+The `gt` CLI is not running or not in PATH. Ensure Gas Town is set up.
+
+### Colors wrong
+
+Run `tmux-rig-status-setup.sh` to fix color settings for your terminal.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,42 @@ Setup scripts, tools, and docs for [Gas Town](https://github.com/steveyegge/gast
 |------|-------------|
 | `setup-town.sh` | Bootstrap a Gas Town instance on fresh Ubuntu/Debian |
 | `telegram-bot/` | Telegram bot for mobile Gas Town control |
+| **`install-tmux.sh`** | **curl\|bash installer for tmux config (standalone)** |
+| `tmux.conf` | Main tmux configuration with Gas Town status bar |
 | `tmux-rig-status.sh` | Second tmux status line showing rig overview |
 | `tmux-status-right.sh` | First line filter — strips rig LEDs (shown on second line) |
 | `tmux-rig-status-setup.sh` | One-time setup for the second status line |
 | **`claude-usage.sh.template`** | **Claude usage tracker (inspired by [claude-counter](https://github.com/she-llac/claude-counter))** |
 | **`install-claude-usage.sh`** | **Installer for Claude usage tracking** |
 | `docs/` | Guides and reference docs |
+
+## Tmux Status Bar (Standalone Install)
+
+Install the Gas Town tmux configuration independently of the rig structure:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erkantaylan/gastown-helper/master/install-tmux.sh | bash
+```
+
+This installs:
+- Scripts to `~/.local/share/gt-tmux/`
+- Config to `~/.config/tmux/tmux.conf`
+
+The config persists across session restarts and doesn't require `$GT_HOME` to be set.
+
+After installing, enable the second status line (rig overview):
+
+```bash
+~/.local/share/gt-tmux/tmux-rig-status-setup.sh
+```
+
+Set your mayor name:
+
+```bash
+echo 'YourName' > ~/.gt-mayor-name
+```
+
+See [docs/tmux-second-status-line.md](docs/tmux-second-status-line.md) for details.
 
 ## Claude Usage Tracking
 
@@ -86,6 +116,7 @@ See [telegram-bot/README.md](telegram-bot/README.md) for setup.
 |-----|-------------|
 | [tmux-statusbar.md](docs/tmux-statusbar.md) | Customize the Gas Town tmux status bar |
 | [tmux-second-status-line.md](docs/tmux-second-status-line.md) | Add a rig overview second status line |
+| **[CLAUDE.md](CLAUDE.md)** | **Agent-friendly quick reference for tmux setup** |
 | **[CLAUDE_USAGE_TRACKING.md](CLAUDE_USAGE_TRACKING.md)** | **Claude usage tracking (adapted from claude-counter)** |
 | [dev-sandbox-setup.md](docs/dev-sandbox-setup.md) | Run Gas Town from source in isolation |
 

--- a/install-tmux.sh
+++ b/install-tmux.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# install-tmux.sh — curl|bash installer for Gas Town tmux configuration
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/erkantaylan/gastown-helper/master/install-tmux.sh | bash
+#
+# What it does:
+#   1. Downloads tmux scripts to ~/.local/share/gt-tmux/
+#   2. Installs tmux.conf to ~/.config/tmux/tmux.conf
+#   3. Reloads tmux configuration if tmux is running
+#
+# The installed config is independent of Gas Town rig structure and persists
+# across session restarts.
+
+set -e
+
+INSTALL_DIR="${GT_TMUX_DIR:-$HOME/.local/share/gt-tmux}"
+CONFIG_DIR="$HOME/.config/tmux"
+REPO_URL="https://raw.githubusercontent.com/erkantaylan/gastown-helper/master"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[info]${NC} $*"; }
+warn() { echo -e "${YELLOW}[warn]${NC} $*"; }
+error() { echo -e "${RED}[error]${NC} $*" >&2; }
+
+# Check for required tools
+check_deps() {
+    local missing=()
+    for cmd in curl python3; do
+        if ! command -v "$cmd" &>/dev/null; then
+            missing+=("$cmd")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        error "Missing required tools: ${missing[*]}"
+        error "Install them and try again."
+        exit 1
+    fi
+}
+
+# Download a file from the repo
+download() {
+    local file="$1"
+    local dest="$2"
+
+    if ! curl -fsSL "$REPO_URL/$file" -o "$dest"; then
+        error "Failed to download $file"
+        return 1
+    fi
+}
+
+# Main installation
+main() {
+    info "Installing Gas Town tmux configuration..."
+
+    check_deps
+
+    # Create directories
+    mkdir -p "$INSTALL_DIR"
+    mkdir -p "$CONFIG_DIR"
+
+    # Download scripts
+    info "Downloading tmux scripts to $INSTALL_DIR/"
+    download "tmux-rig-status.sh" "$INSTALL_DIR/tmux-rig-status.sh"
+    download "tmux-status-right.sh" "$INSTALL_DIR/tmux-status-right.sh"
+    download "tmux-rig-status-setup.sh" "$INSTALL_DIR/tmux-rig-status-setup.sh"
+    download "claude-statusline.sh" "$INSTALL_DIR/claude-statusline.sh"
+
+    # Make scripts executable
+    chmod +x "$INSTALL_DIR"/*.sh
+
+    # Download and install tmux.conf
+    info "Installing tmux.conf to $CONFIG_DIR/"
+
+    # Backup existing config if present
+    if [ -f "$CONFIG_DIR/tmux.conf" ]; then
+        backup="$CONFIG_DIR/tmux.conf.backup.$(date +%Y%m%d_%H%M%S)"
+        warn "Backing up existing tmux.conf to $backup"
+        cp "$CONFIG_DIR/tmux.conf" "$backup"
+    fi
+
+    download "tmux.conf" "$CONFIG_DIR/tmux.conf"
+
+    # Patch tmux.conf to use installed paths
+    info "Configuring paths..."
+    sed -i "s|\$GT_HOME/gthelper/|$INSTALL_DIR/|g" "$CONFIG_DIR/tmux.conf"
+    sed -i "s|\$GT_HOME/services/telegram-bot/|$HOME/.local/bin/|g" "$CONFIG_DIR/tmux.conf"
+
+    # Reload tmux if running
+    if tmux list-sessions &>/dev/null; then
+        info "Reloading tmux configuration..."
+        tmux source-file "$CONFIG_DIR/tmux.conf" 2>/dev/null || warn "Could not reload tmux (you may need to reload manually)"
+    fi
+
+    echo ""
+    info "Installation complete!"
+    echo ""
+    echo "Scripts installed to: $INSTALL_DIR/"
+    echo "Config installed to:  $CONFIG_DIR/tmux.conf"
+    echo ""
+    echo "To enable the second status line with rig overview:"
+    echo "  $INSTALL_DIR/tmux-rig-status-setup.sh"
+    echo ""
+    echo "To reload tmux config manually:"
+    echo "  tmux source-file $CONFIG_DIR/tmux.conf"
+    echo ""
+    echo "To set your mayor name (appears in status bar):"
+    echo "  echo 'YourName' > ~/.gt-mayor-name"
+}
+
+main "$@"

--- a/tmux-rig-status-setup.sh
+++ b/tmux-rig-status-setup.sh
@@ -4,19 +4,68 @@
 # Run once to enable, or add to your tmux.conf / shell profile.
 # To disable: tmux set-option -g status 1
 #
-# Requires GT_HOME environment variable (defaults to parent of gthelper)
+# Script location detection (in priority order):
+#   1. GT_TMUX_DIR env var (custom location)
+#   2. Same directory as this script (for direct execution)
+#   3. ~/.local/share/gt-tmux/ (curl|bash install)
+#   4. $GT_HOME/gthelper/ (manual install)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Auto-detect GT_HOME if not set
-if [ -z "$GT_HOME" ]; then
-    # gthelper is at $GT_HOME/gthelper, so parent is GT_HOME
+# Find the script directory
+find_scripts() {
+    # Check GT_TMUX_DIR first
+    if [ -n "$GT_TMUX_DIR" ] && [ -f "$GT_TMUX_DIR/tmux-rig-status.sh" ]; then
+        echo "$GT_TMUX_DIR"
+        return
+    fi
+
+    # Check same directory as this script
+    if [ -f "$SCRIPT_DIR/tmux-rig-status.sh" ]; then
+        echo "$SCRIPT_DIR"
+        return
+    fi
+
+    # Check curl|bash install location
+    if [ -f "$HOME/.local/share/gt-tmux/tmux-rig-status.sh" ]; then
+        echo "$HOME/.local/share/gt-tmux"
+        return
+    fi
+
+    # Check GT_HOME fallback
+    if [ -n "$GT_HOME" ] && [ -f "$GT_HOME/gthelper/tmux-rig-status.sh" ]; then
+        echo "$GT_HOME/gthelper"
+        return
+    fi
+
+    # Last resort: auto-detect GT_HOME from script location
+    if [ -z "$GT_HOME" ]; then
+        GT_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
+        if [ -f "$GT_HOME/gthelper/tmux-rig-status.sh" ]; then
+            echo "$GT_HOME/gthelper"
+            return
+        fi
+    fi
+
+    # Not found
+    echo ""
+}
+
+SCRIPTS_DIR="$(find_scripts)"
+if [ -z "$SCRIPTS_DIR" ]; then
+    echo "Error: Could not find tmux-rig-status.sh"
+    echo "Run install-tmux.sh first, or set GT_HOME or GT_TMUX_DIR"
+    exit 1
+fi
+
+# Export GT_HOME if we detected it (for telegram bot path)
+if [ -z "$GT_HOME" ] && [ -d "$SCRIPT_DIR/.." ]; then
     GT_HOME="$(cd "$SCRIPT_DIR/.." && pwd)"
     export GT_HOME
 fi
 
-STATUS_SCRIPT="$GT_HOME/gthelper/tmux-rig-status.sh"
-FILTER_SCRIPT="$GT_HOME/gthelper/tmux-status-right.sh"
+STATUS_SCRIPT="$SCRIPTS_DIR/tmux-rig-status.sh"
+FILTER_SCRIPT="$SCRIPTS_DIR/tmux-status-right.sh"
 
 # Enable 2 status lines
 tmux set-option -g status 2
@@ -35,13 +84,28 @@ tmux set-option -g 'status-format[1]' \
 # Mayor name, username, and town directory
 MAYOR_NAME=$(cat ~/.gt-mayor-name 2>/dev/null || echo "Mayor")
 USERNAME=$(whoami)
-TOWN_DIR=$(basename "$GT_HOME")
+TOWN_DIR=$(basename "${GT_HOME:-$HOME}" 2>/dev/null || echo "~")
 
 # Detect bot version and name from deployed binary + .env
-BOT_BIN="$GT_HOME/services/telegram-bot/gt-bot"
-BOT_ENV="$GT_HOME/services/telegram-bot/.env"
-BOT_VERSION=$("$BOT_BIN" --version 2>/dev/null || echo "")
-BOT_NAME=$(grep '^TELEGRAM_BOT_TOKEN=' "$BOT_ENV" 2>/dev/null | cut -d= -f2 | xargs -I{} curl -s "https://api.telegram.org/bot{}/getMe" 2>/dev/null | grep -o '"username":"[^"]*"' | cut -d'"' -f4)
+# Try multiple locations for the bot binary
+BOT_VERSION=""
+BOT_NAME=""
+for bot_path in \
+    "$HOME/.local/bin/gt-bot" \
+    "${GT_HOME:-/nonexistent}/services/telegram-bot/gt-bot" \
+    "$(command -v gt-bot 2>/dev/null)"
+do
+    if [ -x "$bot_path" ]; then
+        BOT_VERSION=$("$bot_path" --version 2>/dev/null || echo "")
+        break
+    fi
+done
+
+# Try to get bot name from .env (if GT_HOME is set)
+if [ -n "$GT_HOME" ] && [ -f "$GT_HOME/services/telegram-bot/.env" ]; then
+    BOT_NAME=$(grep '^TELEGRAM_BOT_TOKEN=' "$GT_HOME/services/telegram-bot/.env" 2>/dev/null | cut -d= -f2 | xargs -I{} curl -s "https://api.telegram.org/bot{}/getMe" 2>/dev/null | grep -o '"username":"[^"]*"' | cut -d'"' -f4)
+fi
+
 BOT_BADGE=""
 if [ -n "$BOT_VERSION" ]; then
     BOT_LABEL="📱${BOT_VERSION}"
@@ -64,8 +128,10 @@ tmux set-option -g window-status-current-format ""
 tmux set-option -g window-status-format ""
 
 echo "✓ Second status line enabled"
+echo "  Scripts: $SCRIPTS_DIR/"
 echo "  Mayor: $MAYOR_NAME (from ~/.gt-mayor-name)"
-echo "  User: ${USERNAME}[${TOWN_DIR}]${BOT_BADGE}"
+echo "  User: ${USERNAME}[${TOWN_DIR}]"
+[ -n "$BOT_VERSION" ] && echo "  Bot: ${BOT_VERSION}${BOT_NAME:+ @$BOT_NAME}"
 echo "  Line 1: agent counts, hooked work, mail (no rig LEDs, no window list)"
 echo "  Line 2: rig names with status icons"
 echo "  Refresh: every $(tmux show-option -gv status-interval 2>/dev/null || echo 5)s"

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,6 +1,14 @@
 # Gas Town tmux config
-# Paths use $GT_HOME which should be set in your shell profile (e.g. ~/.bashrc)
-# Example: export GT_HOME="$HOME/arog"
+#
+# Installation options:
+#   1. curl|bash: curl -fsSL <repo>/install-tmux.sh | bash
+#      → Scripts go to ~/.local/share/gt-tmux/
+#      → Config goes to ~/.config/tmux/tmux.conf (paths auto-patched)
+#
+#   2. Manual: Set GT_HOME in ~/.bashrc and use this file as-is
+#      → Scripts expected at $GT_HOME/gthelper/
+#
+# The scripts themselves also detect their location, so they work either way.
 
 set -g default-terminal "screen-256color"
 set -s escape-time 10


### PR DESCRIPTION
## Summary

- New `install-tmux.sh` - curl|bash installer that downloads tmux scripts to `~/.local/share/gt-tmux/`
- Installs tmux.conf to `~/.config/tmux/tmux.conf` with paths pointing to stable location
- Scripts work standalone without Gas Town rig structure
- Added CLAUDE.md with agent-friendly setup instructions

## Related

Bead: gt-9tnf

🤖 Generated with [Claude Code](https://claude.com/claude-code)